### PR TITLE
initial version of cloud emission estimator

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,73 @@
+[flake8]
+max-line-length = 125
+extend-ignore =
+  # Max line length
+  E501,
+  # Whitespace before ':' (in accordance with Black)
+  E203,
+  # Missing whitespace after ',' (in accordance with Black)
+  E231,
+  # bare-except
+  E722,
+  # Continuation line unaligned for hanging indent
+  E131,
+  # flake8-pytest-style
+  # A flake8 plugin checking common style issues or inconsistencies with pytest-based tests.
+  # Go to the following link to check the current errors reported:
+  # https://github.com/m-burst/flake8-pytest-style
+  # use @pytest.fixture() over @pytest.fixture
+  PT001,
+  # configuration for fixture '{name}' specified via positional args, use kwargs
+  PT002,
+  # scope='function' is implied in @pytest.fixture()
+  PT003,
+  # fixture '{name}' does not return anything, add leading underscore
+  PT004,
+  # fixture '{name}' returns a value, remove leading underscore
+  PT005,
+  # wrong name(s) type in @pytest.mark.parametrize, expected {expected_type}
+  PT006,
+  # wrong values type in @pytest.mark.parametrize, expected {expected_type}
+  PT007,
+  # use return_value= instead of patching with lambda
+  PT008,
+  # use a regular assert instead of unittest-style '{assertion}'
+  PT009,
+  # set the expected exception in pytest.raises()
+  PT010,
+  # pytest.raises({exception}) is too broad, set the match parameter or use a more specific exception
+  PT011,
+  # pytest.raises() block should contain a single simple statement
+  PT012,
+  # found incorrect import of pytest, use simple 'import pytest' instead
+  PT013,
+  # found duplicate test cases {indexes} in @pytest.mark.parametrize
+  ; PT014,
+  # assertion always fails, replace with pytest.fail()
+  PT015,
+  # no message passed to pytest.fail()
+  PT016,
+  # found assertion on exception {name} in except block, use pytest.raises() instead
+  PT017,
+  # assertion should be broken down into multiple parts
+  PT018,
+  # fixture {name} without value is injected as parameter, use @pytest.mark.usefixtures instead
+  PT019,
+  # @pytest.yield_fixture is deprecated, use @pytest.fixture
+  PT020,
+  # use yield instead of request.addfinalizer
+  PT021,
+  # no teardown in fixture {name}, use return instead of yield
+  PT022,
+  # use @pytest.mark.foo() over @pytest.mark.foo
+  PT023,
+  # pytest.mark.asyncio is unnecessary for fixtures
+  PT024,
+  # pytest.mark.usefixtures has no effect on fixtures
+  PT025,
+  # useless pytest.mark.usefixtures without parameters
+  PT026,
+  # use pytest.raises() instead of unittest-style 'assertRaises'
+  PT027,
+
+ban-relative-imports = parents

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+*.pyc
+*~
+.hypothesis/
+.mypy_cache/
+.pytest_cache/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,30 @@
+PYTHON ?= PYTHONDONTWRITEBYTECODE=1 python3
+
+.PHONY: test
+test:
+	$(PYTHON) -m pytest -vv tests/
+
+.PHONY: flake8-src
+flake8-src:
+	$(PYTHON) -m flake8 cloud_emission_estimator/
+
+.PHONY: flake8-test
+flake8-test:
+	$(PYTHON) -m flake8 tests/
+
+.PHONY: flake8
+flake8: flake8-src flake8-test
+
+.PHONY: mypy-src
+mypy-src:
+	mypy cloud_emission_estimator/
+
+.PHONY: mypy-test
+mypy-test:
+	mypy tests/
+
+.PHONY: mypy
+mypy: mypy-src mypy-test
+
+.PHONY: test-static
+test-static: flake8 mypy

--- a/README.md
+++ b/README.md
@@ -1,8 +1,14 @@
-# Cloud Carbon Estimator
+# Cloud Emission Estimator
 
-Cloud Carbon Estimator is a Python based tool for calculating energy usage and carbon emissions based on cloud resource consumption.
+Cloud Emission Estimator is a Python based tool for calculating energy usage and carbon emissions based on cloud resource consumption.
 
 This tool is derived from [Cloud Carbon Footprint](https://github.com/cloud-carbon-footprint/cloud-carbon-footprint/).
+
+## Usage
+
+You can run the tool with the provider sample as follows:
+
+    $ python3 -m cloud_emission_estimator --input samples/data_sample_service_april_2023.json
 
 ## License
 

--- a/cloud_emission_estimator/__init__.py
+++ b/cloud_emission_estimator/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) 2023 Aiven, Helsinki, Finland. https://aiven.io/

--- a/cloud_emission_estimator/__main__.py
+++ b/cloud_emission_estimator/__main__.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2023 Aiven, Helsinki, Finland. https://aiven.io/
+from cloud_emission_estimator.emission_estimator import EmissionEstimator
+from decimal import Decimal
+
+import argparse
+import json
+import logging
+
+
+class json_encoder(json.JSONEncoder):
+    def default(self, obj: object) -> object:
+        if isinstance(obj, Decimal):
+            return str(obj)
+        return json.JSONEncoder.default(self, obj)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--input", required=True, help="Input file with utilization records")
+    parser.add_argument("--verbose", help="Verbose logging")
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.DEBUG if args.verbose else logging.INFO)
+    log = logging.getLogger(__name__)
+
+    with open(args.input) as fh:
+        utilization_records = json.load(fh)
+        log.info("Read %r records in total", len(utilization_records))
+
+    estimator = EmissionEstimator()
+    report = estimator.estimate_emissions(utilization_records=utilization_records)
+
+    print(json.dumps(report, indent=4, cls=json_encoder))

--- a/cloud_emission_estimator/coefficients/__init__.py
+++ b/cloud_emission_estimator/coefficients/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) 2023 Aiven, Helsinki, Finland. https://aiven.io/

--- a/cloud_emission_estimator/coefficients/cpu.py
+++ b/cloud_emission_estimator/coefficients/cpu.py
@@ -1,0 +1,51 @@
+# Copyright (c) 2023 Aiven, Helsinki, Finland. https://aiven.io/
+
+# Constants used for energy consumption & emission calculations
+#
+# The values are captured from Cloud Carbon Footprint project:
+# https://github.com/cloud-carbon-footprint/cloud-carbon-footprint
+
+from decimal import Decimal
+
+
+# Default CPU utilization
+CPU_DEFAULT_UTILIZATION_PCT = Decimal("50")
+
+# CPU power consumption, min/max watts per running hour
+CPU_CONSUMPTION_MIN_WATTS = {
+    "ARM_NEOVERSE_N1": Decimal("1.06"),
+
+    "AMD_EPYC_1ST_GEN": Decimal("0.85"),
+    "AMD_EPYC_2ND_GEN": Decimal("0.47"),
+    "AMD_EPYC_3RD_GEN": Decimal("0.43"),
+
+    "INTEL_SANDY_BRIDGE": Decimal("2.18"),
+    "INTEL_IVY_BRIDGE": Decimal("1.71"),
+    "INTEL_HASWELL": Decimal("1.86"),
+    "INTEL_BROADWELL": Decimal("0.71"),
+    "INTEL_SKYLAKE": Decimal("0.55"),
+    "INTEL_CASCADE_LAKE": Decimal("0.69"),
+    "INTEL_ICE_LAKE": Decimal("0.77"),
+
+    "INTEL_BROADWELL_CLIENT": Decimal("0.71"),
+    "INTEL_SKYLAKE_CLIENT": Decimal("1.82"),
+}
+
+CPU_CONSUMPTION_MAX_WATTS = {
+    "ARM_NEOVERSE_N1": Decimal("1.94"),
+
+    "AMD_EPYC_1ST_GEN": Decimal("2.6"),
+    "AMD_EPYC_2ND_GEN": Decimal("1.69"),
+    "AMD_EPYC_3RD_GEN": Decimal("1.95"),
+
+    "INTEL_SANDY_BRIDGE": Decimal("8.61"),
+    "INTEL_IVY_BRIDGE": Decimal("5.56"),
+    "INTEL_HASWELL": Decimal("5.6"),
+    "INTEL_BROADWELL": Decimal("3.69"),
+    "INTEL_SKYLAKE": Decimal("4.01"),
+    "INTEL_CASCADE_LAKE": Decimal("4.06"),
+    "INTEL_ICE_LAKE": Decimal("3.97"),
+
+    "INTEL_BROADWELL_CLIENT": Decimal("3.69"),
+    "INTEL_SKYLAKE_CLIENT": Decimal("5.86"),
+}

--- a/cloud_emission_estimator/coefficients/memory.py
+++ b/cloud_emission_estimator/coefficients/memory.py
@@ -1,0 +1,11 @@
+# Copyright (c) 2023 Aiven, Helsinki, Finland. https://aiven.io/
+
+# Constants used for energy consumption & emission calculations
+#
+# The values are captured from Cloud Carbon Footprint project:
+# https://github.com/cloud-carbon-footprint/cloud-carbon-footprint
+
+from decimal import Decimal
+
+
+MEMORY_CONSUMPTION_WATTS_PER_GB_HOUR = Decimal("0.392")

--- a/cloud_emission_estimator/coefficients/pue.py
+++ b/cloud_emission_estimator/coefficients/pue.py
@@ -1,0 +1,32 @@
+# Copyright (c) 2023 Aiven, Helsinki, Finland. https://aiven.io/
+
+# Constants used for energy consumption & emission calculations
+#
+# The values are captured from Cloud Carbon Footprint project:
+# https://github.com/cloud-carbon-footprint/cloud-carbon-footprint
+
+from decimal import Decimal
+
+
+POWER_USAGE_EFFECTIVINESS = {
+    "aws": {
+        "default": Decimal("1.135"),
+    },
+
+    "google": {
+        "asia-east1": Decimal("1.12"),
+        "asia-southeast1": Decimal("1.13"),
+        "australia-southeast1": Decimal("1.10"),
+        "europe-north1": Decimal("1.09"),
+        "europe-west1": Decimal("1.09"),
+        "europe-west4": Decimal("1.07"),
+        "us-central1": Decimal("1.11"),
+        "us-central2": Decimal("1.11"),
+        "us-east4": Decimal("1.08"),
+        "default": Decimal("1.1"),  # PUE fleet wide average
+    },
+
+    "default": {
+        "default": Decimal("1.58"),
+    },
+}

--- a/cloud_emission_estimator/coefficients/volume.py
+++ b/cloud_emission_estimator/coefficients/volume.py
@@ -1,0 +1,29 @@
+# Copyright (c) 2023 Aiven, Helsinki, Finland. https://aiven.io/
+
+# Constants used for energy consumption & emission calculations
+#
+# The values are captured from Cloud Carbon Footprint project:
+# https://github.com/cloud-carbon-footprint/cloud-carbon-footprint
+
+from decimal import Decimal
+
+
+VOLUME_CONSUMPTION_WATTS_PER_GB_HOUR_SSD_DEFAULT = Decimal("0.000392")
+
+VOLUME_CONSUMPTION_WATTS_PER_GB_HOUR = {
+    "aws": {
+        "ssd": {
+            "default": VOLUME_CONSUMPTION_WATTS_PER_GB_HOUR_SSD_DEFAULT * 2,  # Replication factor 2
+        },
+    },
+    "google": {
+        "ssd": {
+            "default": VOLUME_CONSUMPTION_WATTS_PER_GB_HOUR_SSD_DEFAULT * 2,  # Replication factor 2
+        }
+    },
+    "default": {
+        "ssd": {
+            "default": VOLUME_CONSUMPTION_WATTS_PER_GB_HOUR_SSD_DEFAULT,
+        }
+    }
+}

--- a/cloud_emission_estimator/emission_estimator.py
+++ b/cloud_emission_estimator/emission_estimator.py
@@ -1,0 +1,139 @@
+# Copyright (c) 2023 Aiven, Helsinki, Finland. https://aiven.io/
+
+# Estimate cloud based emissions based on a collected set of utilization records
+#
+# This tool is derives from Cloud Carbon Footpring, https://github.com/cloud-carbon-footprint/cloud-carbon-footprint/
+
+from cloud_emission_estimator.coefficients.cpu import CPU_CONSUMPTION_MIN_WATTS, CPU_CONSUMPTION_MAX_WATTS, CPU_DEFAULT_UTILIZATION_PCT
+from cloud_emission_estimator.coefficients.memory import MEMORY_CONSUMPTION_WATTS_PER_GB_HOUR
+from cloud_emission_estimator.coefficients.pue import POWER_USAGE_EFFECTIVINESS
+from cloud_emission_estimator.coefficients.volume import VOLUME_CONSUMPTION_WATTS_PER_GB_HOUR
+from decimal import Decimal
+from functools import cache
+
+import logging
+
+
+class EmissionEstimator:
+    def __init__(self) -> None:
+        self.log = logging.getLogger(__name__)
+
+    @cache
+    def lookup_pue_by_provider_and_region(self, *, provider: str, region: str) -> Decimal:
+        pue = POWER_USAGE_EFFECTIVINESS["default"]["default"]
+
+        if provider in POWER_USAGE_EFFECTIVINESS:
+            if region and region in POWER_USAGE_EFFECTIVINESS[provider]:
+                pue = POWER_USAGE_EFFECTIVINESS[provider][region]
+            elif "default" in POWER_USAGE_EFFECTIVINESS[provider]:
+                pue = POWER_USAGE_EFFECTIVINESS[provider]["default"]
+        elif provider:
+            self.log.warning("No PUE information found for provider %r", provider)
+
+        return pue
+
+    @cache
+    def lookup_volume_consumption_by_provider_region_and_type(self, *, provider: str, region: str, volume_type: str = "ssd") -> Decimal:
+        per_gb_hour_consumption = VOLUME_CONSUMPTION_WATTS_PER_GB_HOUR["default"][volume_type]["default"]
+
+        if provider in VOLUME_CONSUMPTION_WATTS_PER_GB_HOUR:
+            if region and region in VOLUME_CONSUMPTION_WATTS_PER_GB_HOUR[provider][volume_type]:
+                per_gb_hour_consumption = VOLUME_CONSUMPTION_WATTS_PER_GB_HOUR[provider][volume_type][region]
+            elif "default" in VOLUME_CONSUMPTION_WATTS_PER_GB_HOUR[provider][volume_type]:
+                per_gb_hour_consumption = VOLUME_CONSUMPTION_WATTS_PER_GB_HOUR[provider][volume_type]["default"]
+        elif provider:
+            self.log.warning("No volume consumption factors found for provider %r", provider)
+
+        return per_gb_hour_consumption
+
+    def lookup_pue(self, *, utilization_record: dict) -> Decimal:
+        provider = utilization_record.get("provider")
+        region = utilization_record.get("region")
+
+        return self.lookup_pue_by_provider_and_region(provider=provider, region=region)
+
+    def estimate_energy_consumption_cpu(self, *, utilization_record: dict) -> Decimal:
+        # Energy consumption estimate for CPU consumption
+        # Result in Watt-hours
+        #
+        # Calculated as:
+        #  scaled watts per hour based on cpu utilization *
+        #  number of cpus *
+        #  running hours *
+        #  power usage effeciviness
+        min_watts = CPU_CONSUMPTION_MIN_WATTS[utilization_record["cpu_type"]]
+        max_watts = CPU_CONSUMPTION_MAX_WATTS[utilization_record["cpu_type"]]
+        cpu_utilization = Decimal(utilization_record.get("cpu_utilization_pct", CPU_DEFAULT_UTILIZATION_PCT))
+
+        pue = self.lookup_pue(utilization_record=utilization_record)
+
+        return (
+            (min_watts + (max_watts - min_watts) * cpu_utilization / 100) *
+            Decimal(utilization_record.get("cpu_count", 1)) *
+            Decimal(utilization_record["running_hours"]) *
+            pue
+        )
+
+    def estimate_energy_consumption_memory(self, *, utilization_record: dict) -> Decimal:
+        # Energy consumption estimate for memory usage
+        # Result in Watt-hours
+        pue = self.lookup_pue(utilization_record=utilization_record)
+        return (
+            Decimal(utilization_record["memory_gb"]) *
+            MEMORY_CONSUMPTION_WATTS_PER_GB_HOUR *
+            Decimal(utilization_record["running_hours"]) *
+            pue
+        )
+
+    def estimate_energy_consumption_volume(self, *, utilization_record: dict) -> Decimal:
+        # Energy consumption estimate for memory usage
+        # Result in Watt-hours
+        pue = self.lookup_pue(utilization_record=utilization_record)
+
+        provider = utilization_record.get("provider")
+        region = utilization_record.get("region")
+        volume_type = utilization_record.get("volume_type", "ssd")
+        per_gb_hour_consumption = self.lookup_volume_consumption_by_provider_region_and_type(
+            provider=provider,
+            region=region,
+            volume_type=volume_type,
+        )
+
+        return (
+            Decimal(utilization_record["volume_gb"]) *
+            per_gb_hour_consumption *
+            Decimal(utilization_record["running_hours"]) *
+            pue
+        )
+
+    def estimate_energy_consumption_for_utilization_record(self, *, utilization_record: dict) -> Decimal:
+        # Energy consumption estimate for a single record
+        # Result in Watt-hours
+        record_class = utilization_record.get("class")
+
+        energy_estimate = Decimal(0)
+        if record_class == "virtual_machine":
+            energy_estimate = self.estimate_energy_consumption_cpu(utilization_record=utilization_record)
+            energy_estimate += self.estimate_energy_consumption_memory(utilization_record=utilization_record)
+        elif record_class == "volume":
+            energy_estimate = self.estimate_energy_consumption_volume(utilization_record=utilization_record)
+
+        return energy_estimate
+
+    def estimate_emissions(self, *, utilization_records: list[dict]) -> dict:
+        report = {
+            "total": {
+                "energy_wh": Decimal(0),
+            }
+        }
+
+        for utilization_record in utilization_records:
+            energy_estimate = self.estimate_energy_consumption_for_utilization_record(utilization_record=utilization_record)
+            report["total"]["energy_wh"] += energy_estimate
+
+        # convert units to kWh
+        for result_record in report.values():
+            energy_kwh = result_record.pop("energy_wh") / 1000
+            result_record["energy_kwh"] = energy_kwh.quantize(Decimal("0.00"))
+
+        return report

--- a/doc/samples/data_sample_service_april_2023.json
+++ b/doc/samples/data_sample_service_april_2023.json
@@ -1,0 +1,515 @@
+[
+  {
+    "class": "virtual_machine",
+    "provider": "google",
+    "region": "europe-west1",
+    "instance_type": "n2d-standard-8",
+    "running_hours": "720",
+    "cpu_count": 8,
+    "memory_gb": 32,
+    "cpu_utilization": "50.0",
+    "cpu_type": "AMD_EPYC_3RD_GEN"
+  },
+  {
+    "class": "virtual_machine",
+    "provider": "google",
+    "region": "europe-west1",
+    "instance_type": "n2d-standard-8",
+    "running_hours": "720",
+    "cpu_count": 8,
+    "memory_gb": 32,
+    "cpu_utilization": "50.0",
+    "cpu_type": "AMD_EPYC_3RD_GEN"
+  },
+  {
+    "class": "virtual_machine",
+    "provider": "google",
+    "region": "europe-west1",
+    "instance_type": "n2d-standard-8",
+    "running_hours": "720",
+    "cpu_count": 8,
+    "memory_gb": 32,
+    "cpu_utilization": "50.0",
+    "cpu_type": "AMD_EPYC_3RD_GEN"
+  },
+  {
+    "class": "virtual_machine",
+    "provider": "google",
+    "region": "europe-west1",
+    "instance_type": "n2d-standard-8",
+    "running_hours": "720",
+    "cpu_count": 8,
+    "memory_gb": 32,
+    "cpu_utilization": "50.0",
+    "cpu_type": "AMD_EPYC_3RD_GEN"
+  },
+  {
+    "class": "virtual_machine",
+    "provider": "google",
+    "region": "europe-west1",
+    "instance_type": "n2d-standard-8",
+    "running_hours": "720",
+    "cpu_count": 8,
+    "memory_gb": 32,
+    "cpu_utilization": "50.0",
+    "cpu_type": "AMD_EPYC_3RD_GEN"
+  },
+  {
+    "class": "virtual_machine",
+    "provider": "google",
+    "region": "europe-west1",
+    "instance_type": "n2d-standard-8",
+    "running_hours": "720",
+    "cpu_count": 8,
+    "memory_gb": 32,
+    "cpu_utilization": "50.0",
+    "cpu_type": "AMD_EPYC_3RD_GEN"
+  },
+  {
+    "class": "virtual_machine",
+    "provider": "google",
+    "region": "europe-west1",
+    "instance_type": "n2d-standard-8",
+    "running_hours": "720",
+    "cpu_count": 8,
+    "memory_gb": 32,
+    "cpu_utilization": "50.0",
+    "cpu_type": "AMD_EPYC_3RD_GEN"
+  },
+  {
+    "class": "virtual_machine",
+    "provider": "google",
+    "region": "europe-west1",
+    "instance_type": "n2d-standard-8",
+    "running_hours": "720",
+    "cpu_count": 8,
+    "memory_gb": 32,
+    "cpu_utilization": "50.0",
+    "cpu_type": "AMD_EPYC_3RD_GEN"
+  },
+  {
+    "class": "virtual_machine",
+    "provider": "google",
+    "region": "europe-west1",
+    "instance_type": "n2d-standard-8",
+    "running_hours": "720",
+    "cpu_count": 8,
+    "memory_gb": 32,
+    "cpu_utilization": "50.0",
+    "cpu_type": "AMD_EPYC_3RD_GEN"
+  },
+  {
+    "class": "virtual_machine",
+    "provider": "google",
+    "region": "europe-west1",
+    "instance_type": "n2d-standard-8",
+    "running_hours": "720",
+    "cpu_count": 8,
+    "memory_gb": 32,
+    "cpu_utilization": "50.0",
+    "cpu_type": "AMD_EPYC_3RD_GEN"
+  },
+  {
+    "class": "virtual_machine",
+    "provider": "google",
+    "region": "europe-west1",
+    "instance_type": "n2d-standard-8",
+    "running_hours": "720",
+    "cpu_count": 8,
+    "memory_gb": 32,
+    "cpu_utilization": "50.0",
+    "cpu_type": "AMD_EPYC_3RD_GEN"
+  },
+  {
+    "class": "virtual_machine",
+    "provider": "google",
+    "region": "europe-west1",
+    "instance_type": "n2d-standard-8",
+    "running_hours": "720",
+    "cpu_count": 8,
+    "memory_gb": 32,
+    "cpu_utilization": "50.0",
+    "cpu_type": "AMD_EPYC_3RD_GEN"
+  },
+  {
+    "class": "virtual_machine",
+    "provider": "google",
+    "region": "europe-west1",
+    "instance_type": "n2d-standard-8",
+    "running_hours": "720",
+    "cpu_count": 8,
+    "memory_gb": 32,
+    "cpu_utilization": "50.0",
+    "cpu_type": "AMD_EPYC_3RD_GEN"
+  },
+  {
+    "class": "virtual_machine",
+    "provider": "google",
+    "region": "europe-west1",
+    "instance_type": "n2d-standard-8",
+    "running_hours": "720",
+    "cpu_count": 8,
+    "memory_gb": 32,
+    "cpu_utilization": "50.0",
+    "cpu_type": "AMD_EPYC_3RD_GEN"
+  },
+  {
+    "class": "virtual_machine",
+    "provider": "google",
+    "region": "europe-west1",
+    "instance_type": "n2d-standard-8",
+    "running_hours": "720",
+    "cpu_count": 8,
+    "memory_gb": 32,
+    "cpu_utilization": "50.0",
+    "cpu_type": "AMD_EPYC_3RD_GEN"
+  },
+  {
+    "class": "virtual_machine",
+    "provider": "google",
+    "region": "europe-west1",
+    "instance_type": "n2d-standard-8",
+    "running_hours": "720",
+    "cpu_count": 8,
+    "memory_gb": 32,
+    "cpu_utilization": "50.0",
+    "cpu_type": "AMD_EPYC_3RD_GEN"
+  },
+  {
+    "class": "virtual_machine",
+    "provider": "google",
+    "region": "europe-west1",
+    "instance_type": "n2d-standard-8",
+    "running_hours": "720",
+    "cpu_count": 8,
+    "memory_gb": 32,
+    "cpu_utilization": "50.0",
+    "cpu_type": "AMD_EPYC_3RD_GEN"
+  },
+  {
+    "class": "virtual_machine",
+    "provider": "google",
+    "region": "europe-west1",
+    "instance_type": "n2d-standard-8",
+    "running_hours": "720",
+    "cpu_count": 8,
+    "memory_gb": 32,
+    "cpu_utilization": "50.0",
+    "cpu_type": "AMD_EPYC_3RD_GEN"
+  },
+  {
+    "class": "virtual_machine",
+    "provider": "google",
+    "region": "europe-west1",
+    "instance_type": "n2d-standard-8",
+    "running_hours": "720",
+    "cpu_count": 8,
+    "memory_gb": 32,
+    "cpu_utilization": "50.0",
+    "cpu_type": "AMD_EPYC_3RD_GEN"
+  },
+  {
+    "class": "virtual_machine",
+    "provider": "google",
+    "region": "europe-west1",
+    "instance_type": "n2d-standard-8",
+    "running_hours": "720",
+    "cpu_count": 8,
+    "memory_gb": 32,
+    "cpu_utilization": "50.0",
+    "cpu_type": "AMD_EPYC_3RD_GEN"
+  },
+  {
+    "class": "virtual_machine",
+    "provider": "google",
+    "region": "europe-west1",
+    "instance_type": "n2d-standard-8",
+    "running_hours": "720",
+    "cpu_count": 8,
+    "memory_gb": 32,
+    "cpu_utilization": "50.0",
+    "cpu_type": "AMD_EPYC_3RD_GEN"
+  },
+  {
+    "class": "virtual_machine",
+    "provider": "google",
+    "region": "europe-west1",
+    "instance_type": "n2d-standard-8",
+    "running_hours": "720",
+    "cpu_count": 8,
+    "memory_gb": 32,
+    "cpu_utilization": "50.0",
+    "cpu_type": "AMD_EPYC_3RD_GEN"
+  },
+  {
+    "class": "virtual_machine",
+    "provider": "google",
+    "region": "europe-west1",
+    "instance_type": "n2d-standard-8",
+    "running_hours": "720",
+    "cpu_count": 8,
+    "memory_gb": 32,
+    "cpu_utilization": "50.0",
+    "cpu_type": "AMD_EPYC_3RD_GEN"
+  },
+  {
+    "class": "virtual_machine",
+    "provider": "google",
+    "region": "europe-west1",
+    "instance_type": "n2d-standard-8",
+    "running_hours": "720",
+    "cpu_count": 8,
+    "memory_gb": 32,
+    "cpu_utilization": "50.0",
+    "cpu_type": "AMD_EPYC_3RD_GEN"
+  },
+  {
+    "class": "virtual_machine",
+    "provider": "google",
+    "region": "europe-west1",
+    "instance_type": "n2d-standard-8",
+    "running_hours": "720",
+    "cpu_count": 8,
+    "memory_gb": 32,
+    "cpu_utilization": "50.0",
+    "cpu_type": "AMD_EPYC_3RD_GEN"
+  },
+  {
+    "class": "virtual_machine",
+    "provider": "google",
+    "region": "europe-west1",
+    "instance_type": "n2d-standard-8",
+    "running_hours": "720",
+    "cpu_count": 8,
+    "memory_gb": 32,
+    "cpu_utilization": "50.0",
+    "cpu_type": "AMD_EPYC_3RD_GEN"
+  },
+  {
+    "class": "virtual_machine",
+    "provider": "google",
+    "region": "europe-west1",
+    "instance_type": "n2d-standard-8",
+    "running_hours": "720",
+    "cpu_count": 8,
+    "memory_gb": 32,
+    "cpu_utilization": "50.0",
+    "cpu_type": "AMD_EPYC_3RD_GEN"
+  },
+  {
+    "class": "volume",
+    "provider": "google",
+    "region": "europe-west1",
+    "running_hours": "720",
+    "volume_gb": "3026",
+    "volume_type": "ssd"
+  },
+  {
+    "class": "volume",
+    "provider": "google",
+    "region": "europe-west1",
+    "running_hours": "720",
+    "volume_gb": "3026",
+    "volume_type": "ssd"
+  },
+  {
+    "class": "volume",
+    "provider": "google",
+    "region": "europe-west1",
+    "running_hours": "720",
+    "volume_gb": "3026",
+    "volume_type": "ssd"
+  },
+  {
+    "class": "volume",
+    "provider": "google",
+    "region": "europe-west1",
+    "running_hours": "720",
+    "volume_gb": "3026",
+    "volume_type": "ssd"
+  },
+  {
+    "class": "volume",
+    "provider": "google",
+    "region": "europe-west1",
+    "running_hours": "720",
+    "volume_gb": "3026",
+    "volume_type": "ssd"
+  },
+  {
+    "class": "volume",
+    "provider": "google",
+    "region": "europe-west1",
+    "running_hours": "720",
+    "volume_gb": "3026",
+    "volume_type": "ssd"
+  },
+  {
+    "class": "volume",
+    "provider": "google",
+    "region": "europe-west1",
+    "running_hours": "720",
+    "volume_gb": "3026",
+    "volume_type": "ssd"
+  },
+  {
+    "class": "volume",
+    "provider": "google",
+    "region": "europe-west1",
+    "running_hours": "720",
+    "volume_gb": "3026",
+    "volume_type": "ssd"
+  },
+  {
+    "class": "volume",
+    "provider": "google",
+    "region": "europe-west1",
+    "running_hours": "720",
+    "volume_gb": "3026",
+    "volume_type": "ssd"
+  },
+  {
+    "class": "volume",
+    "provider": "google",
+    "region": "europe-west1",
+    "running_hours": "720",
+    "volume_gb": "3026",
+    "volume_type": "ssd"
+  },
+  {
+    "class": "volume",
+    "provider": "google",
+    "region": "europe-west1",
+    "running_hours": "720",
+    "volume_gb": "3026",
+    "volume_type": "ssd"
+  },
+  {
+    "class": "volume",
+    "provider": "google",
+    "region": "europe-west1",
+    "running_hours": "720",
+    "volume_gb": "3026",
+    "volume_type": "ssd"
+  },
+  {
+    "class": "volume",
+    "provider": "google",
+    "region": "europe-west1",
+    "running_hours": "720",
+    "volume_gb": "3026",
+    "volume_type": "ssd"
+  },
+  {
+    "class": "volume",
+    "provider": "google",
+    "region": "europe-west1",
+    "running_hours": "720",
+    "volume_gb": "3026",
+    "volume_type": "ssd"
+  },
+  {
+    "class": "volume",
+    "provider": "google",
+    "region": "europe-west1",
+    "running_hours": "720",
+    "volume_gb": "3026",
+    "volume_type": "ssd"
+  },
+  {
+    "class": "volume",
+    "provider": "google",
+    "region": "europe-west1",
+    "running_hours": "720",
+    "volume_gb": "3026",
+    "volume_type": "ssd"
+  },
+  {
+    "class": "volume",
+    "provider": "google",
+    "region": "europe-west1",
+    "running_hours": "720",
+    "volume_gb": "3026",
+    "volume_type": "ssd"
+  },
+  {
+    "class": "volume",
+    "provider": "google",
+    "region": "europe-west1",
+    "running_hours": "720",
+    "volume_gb": "3026",
+    "volume_type": "ssd"
+  },
+  {
+    "class": "volume",
+    "provider": "google",
+    "region": "europe-west1",
+    "running_hours": "720",
+    "volume_gb": "3026",
+    "volume_type": "ssd"
+  },
+  {
+    "class": "volume",
+    "provider": "google",
+    "region": "europe-west1",
+    "running_hours": "720",
+    "volume_gb": "3026",
+    "volume_type": "ssd"
+  },
+  {
+    "class": "volume",
+    "provider": "google",
+    "region": "europe-west1",
+    "running_hours": "720",
+    "volume_gb": "3026",
+    "volume_type": "ssd"
+  },
+  {
+    "class": "volume",
+    "provider": "google",
+    "region": "europe-west1",
+    "running_hours": "720",
+    "volume_gb": "3026",
+    "volume_type": "ssd"
+  },
+  {
+    "class": "volume",
+    "provider": "google",
+    "region": "europe-west1",
+    "running_hours": "720",
+    "volume_gb": "3026",
+    "volume_type": "ssd"
+  },
+  {
+    "class": "volume",
+    "provider": "google",
+    "region": "europe-west1",
+    "running_hours": "720",
+    "volume_gb": "3026",
+    "volume_type": "ssd"
+  },
+  {
+    "class": "volume",
+    "provider": "google",
+    "region": "europe-west1",
+    "running_hours": "720",
+    "volume_gb": "3026",
+    "volume_type": "ssd"
+  },
+  {
+    "class": "volume",
+    "provider": "google",
+    "region": "europe-west1",
+    "running_hours": "720",
+    "volume_gb": "3026",
+    "volume_type": "ssd"
+  },
+  {
+    "class": "volume",
+    "provider": "google",
+    "region": "europe-west1",
+    "running_hours": "720",
+    "volume_gb": "3026",
+    "volume_type": "ssd"
+  }
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[tool.mypy]
+disallow_incomplete_defs = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+
+warn_return_any = true
+warn_unused_configs = true

--- a/tests/test_estimator.py
+++ b/tests/test_estimator.py
@@ -1,0 +1,38 @@
+from cloud_emission_estimator.emission_estimator import EmissionEstimator
+
+
+def test_estimator_virtual_machine() -> None:
+    estimator = EmissionEstimator()
+
+    test_record = {
+        "class": "virtual_machine",
+        "cpu_count": 16,
+        "cpu_type": "INTEL_ICE_LAKE",
+        "running_hours": "12",
+        "memory_gb": "16",
+    }
+
+    energy_consumption_estimate_cpu = estimator.estimate_energy_consumption_cpu(utilization_record=test_record)
+    energy_consumption_estimate_mem = estimator.estimate_energy_consumption_memory(utilization_record=test_record)
+
+    assert energy_consumption_estimate_cpu > 0
+    assert energy_consumption_estimate_cpu > 0
+
+    energy_consumption_estimate_total = estimator.estimate_energy_consumption_for_utilization_record(utilization_record=test_record)
+
+    assert (energy_consumption_estimate_cpu + energy_consumption_estimate_mem) == energy_consumption_estimate_total
+
+
+def test_estimator_volume() -> None:
+    estimator = EmissionEstimator()
+
+    test_record = {
+        "class": "volume",
+        "volume_gb": 10,
+        "volume_type": "ssd",
+        "running_hours": "12",
+    }
+
+    energy_consumption_estimate = estimator.estimate_energy_consumption_volume(utilization_record=test_record)
+
+    assert energy_consumption_estimate > 0


### PR DESCRIPTION
Cloud Emission Estimator is a Python based tool for calculating energy usage and carbon emissions based on cloud resource consumption.

This tool derives from Cloud Carbon Footprint tool at https://github.com/cloud-carbon-footprint/cloud-carbon-footprint/.

The main driver for creating this tooling is to be able to estimate emissions based on external accounting of provisioned resources over straight cloud billing data. External accounting and using prepared utilization records enables few core benefits:

1) We can use any grouping method suitable independent of e.g. tagging capabilities of the cloud in question.
2) We can use arbitrary time spans for assessing energy consumption and emissions.
3) We can extend the calculations to providers that don't necessarily expose granular utilization data through billing/reporting functionality.