### PR TITLE
Fix grid carbon intensity lookup for providers

### DIFF
--- a/cloud_emission_estimator/emission_estimator.py
+++ b/cloud_emission_estimator/emission_estimator.py
@@ -60,7 +60,7 @@ class EmissionEstimator:
         grams_per_kwh = CARBON_INTENSITY_GRAMS_PER_KWH["default"]["default"]
 
         if provider in CARBON_INTENSITY_GRAMS_PER_KWH:
-            if region and region in CARBON_INTENSITY_GRAMS_PER_KWH:
+            if region and region in CARBON_INTENSITY_GRAMS_PER_KWH[provider]:
                 grams_per_kwh = CARBON_INTENSITY_GRAMS_PER_KWH[provider][region]
             elif "default" in CARBON_INTENSITY_GRAMS_PER_KWH[provider]:
                 grams_per_kwh = CARBON_INTENSITY_GRAMS_PER_KWH[provider]["default"]


### PR DESCRIPTION
Lookup for provider/location GCI number was invalid, and only used default for provider for all regions.

Correct and add a simple test.