### PR TITLE
return co2eq_kg value instead of co2eq_mtons

### DIFF
--- a/cloud_emission_estimator/emission_estimator.py
+++ b/cloud_emission_estimator/emission_estimator.py
@@ -203,8 +203,7 @@ class EmissionEstimator:
             co2eq_grams = result_record["co2eq_grams"]
             if co2eq_grams > 0:
                 co2eq_kg = co2eq_grams / 1000
-                co2eq_mtons = co2eq_kg / 1000
-                group_record["co2eq_mtons"] = co2eq_mtons.quantize(Decimal("0.00"))
+                group_record["co2eq_kg"] = co2eq_kg.quantize(Decimal("0.00"))
 
             if group_name == "total":
                 report["total"] = group_record

--- a/tests/test_estimator.py
+++ b/tests/test_estimator.py
@@ -165,4 +165,4 @@ def test_gci_impact_between_regions() -> None:
     report_us = cloud_emission_estimator.estimate_emissions(utilization_records=sample_records_aws_us)
     report_eu = cloud_emission_estimator.estimate_emissions(utilization_records=sample_records_aws_eu)
     assert report_us["total"]["energy_kwh"] == report_eu["total"]["energy_kwh"]
-    assert report_us["total"]["co2eq_mtons"] != report_eu["total"]["co2eq_mtons"]
+    assert report_us["total"]["co2eq_kg"] != report_eu["total"]["co2eq_kg"]


### PR DESCRIPTION
With smaller nodes and little usage, the calculations might return 0.00 in tCO2e but it doesn't mean the emissions are zero or insignificant. Returning kgCO2e is a more flexible value and works with smaller resource consumption estimation as well.